### PR TITLE
Fix issue #59: vampiric blow

### DIFF
--- a/src/skill.c
+++ b/src/skill.c
@@ -342,9 +342,11 @@ vampiric_blow_skill(Skill *skill, SkillData *data)
 		player->stats.advantage = true;
 		CombatResult result = stats_fight(&player->stats, &monster->stats);
 		player->stats.advantage = false;
+
+		monster_hit(monster, result.dmg, result.critical);
+
 		if (result.dmg) {
 			mixer_play_effect(SWORD_HIT);
-			monster_hit(monster, result.dmg, result.critical);
 			monster_set_bleeding(monster);
 
 			unsigned int gain = player->stats.lvl * 3;


### PR DESCRIPTION
Issue : Missing with vampiric blow doesn't seem to trigger a 'Dodge' action text #59

Problem : only if dmg > 0 the function monster_hit is called which generated the "Dodged" effect.