### PR TITLE
Removes steam api call RequestCurrentStats

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,8 +11,8 @@ set(breakhack_PATCH_VERSION 3)
 set(breakhack_RELEASE_TYPE "")
 
 # Checksums
-set(breakhack_STEAMAPI_DLL_CHECKSUM 0x1a20dd5)
-set(breakhack_STEAMAPI_SO_CHECKSUM 0x19f8c71)
+set(breakhack_STEAMAPI_DLL_CHECKSUM 0x1a4691a)
+set(breakhack_STEAMAPI_SO_CHECKSUM 0x1a11b6d)
 
 include(build_deps/cmake/FindCCache.cmake)
 include(build_deps/cmake/FindCMocka.cmake)

--- a/lib/steamworks_c_wrapper/src/CallbackHandler.cpp
+++ b/lib/steamworks_c_wrapper/src/CallbackHandler.cpp
@@ -19,22 +19,10 @@
 #include "CallbackHandler.h"
 
 CallbackHandler::CallbackHandler(int64 appId) :
-	m_CallbackUserStatsReceived(this, &CallbackHandler::OnUserStatsReceived),
 	m_CallbackUserStatsStored(this, &CallbackHandler::OnUserStatsStored),
 	m_AppId(appId)
 {
 	// Nothing
-}
-
-void
-CallbackHandler::OnUserStatsReceived(UserStatsReceived_t *pCallback)
-{
-	if (m_AppId != pCallback->m_nGameID)
-		return;
-
-	m_bStatsCallbackReceived = true;
-	if (statsReceivedCb && k_EResultOK == pCallback->m_eResult)
-		statsReceivedCb();
 }
 
 void
@@ -45,11 +33,6 @@ CallbackHandler::OnUserStatsStored(UserStatsStored_t *pCallback)
 
 	if (statsStoredCb && k_EResultOK == pCallback->m_eResult)
 		statsStoredCb();
-}
-
-bool CallbackHandler::CallbackReceived() const
-{
-	return m_bStatsCallbackReceived;
 }
 
 void CallbackHandler::OnFindLeaderboard(LeaderboardFindResult_t * pCallback, bool bIOFailiure)

--- a/lib/steamworks_c_wrapper/src/CallbackHandler.h
+++ b/lib/steamworks_c_wrapper/src/CallbackHandler.h
@@ -29,11 +29,9 @@ private:
 
 public:
 	CallbackHandler(int64 appId);
-	STEAM_CALLBACK(CallbackHandler, OnUserStatsReceived, UserStatsReceived_t, m_CallbackUserStatsReceived);
 	STEAM_CALLBACK(CallbackHandler, OnUserStatsStored, UserStatsStored_t, m_CallbackUserStatsStored);
 	CCallResult<CallbackHandler, LeaderboardFindResult_t> m_FindLeaderboardCallResult;
 
-	void(*statsReceivedCb)() = nullptr;
 	void(*statsStoredCb)() = nullptr;
 	void(*leaderboardReceivedCb)(int64_t, const char*) = nullptr;
 

--- a/lib/steamworks_c_wrapper/src/steamworks_c_wrapper.cpp
+++ b/lib/steamworks_c_wrapper/src/steamworks_c_wrapper.cpp
@@ -59,9 +59,8 @@ c_SteamAPI_RunCallbacks(void)
 		SteamAPI_RunCallbacks();
 }
 
-extern "C" void c_SteamAPI_SetCallbacks(void(*recvCB)(void), void(*storCB)(void), void(*recvLB)(int64_t, const char *))
+extern "C" void c_SteamAPI_SetCallbacks(void(*storCB)(void), void(*recvLB)(int64_t, const char *))
 {
-	m_CallbackHandler->statsReceivedCb = recvCB;
 	m_CallbackHandler->statsStoredCb = storCB;
 	m_CallbackHandler->leaderboardReceivedCb = recvLB;
 }
@@ -74,20 +73,9 @@ c_SteamAPI_Shutdown()
 }
 
 extern "C" bool
-c_SteamUserStats_RequestCurrentStats()
-{
-	if (NULL == SteamUserStats() || NULL == SteamUser())
-		return false;
-	if (!SteamUser()->BLoggedOn())
-		return false;
-
-	return SteamUserStats()->RequestCurrentStats();
-}
-
-extern "C" bool
 c_SteamUserStats_SetAchievement(const char *pchName)
 {
-	if (m_CallbackHandler && !m_CallbackHandler->CallbackReceived())
+	if (m_CallbackHandler == nullptr)
 		return false;
 
 	bool result = SteamUserStats()->SetAchievement(pchName);

--- a/lib/steamworks_c_wrapper/src/steamworks_c_wrapper.h
+++ b/lib/steamworks_c_wrapper/src/steamworks_c_wrapper.h
@@ -19,6 +19,7 @@
 #pragma once
 
 #include <stdint.h>
+#include <stdbool.h>
 
 int64_t
 c_SteamAPI_Init(void);
@@ -33,10 +34,7 @@ void
 c_SteamAPI_RunCallbacks(void);
 
 void
-c_SteamAPI_SetCallbacks(void(*recvCB)(void), void(*storCB)(void), void(*recvLB)(int64_t, const char *));
-
-bool
-c_SteamUserStats_RequestCurrentStats(void);
+c_SteamAPI_SetCallbacks(void(*storCB)(void), void(*recvLB)(int64_t, const char *));
 
 bool
 c_SteamUserStats_SetAchievement(const char *id);

--- a/src/steam/steamworks_api_wrapper.c
+++ b/src/steam/steamworks_api_wrapper.c
@@ -29,7 +29,6 @@ static Achievement g_Achievements[] = {
 static Uint8 numAchievements = 7;
 
 static bool m_Initiated = false;
-static bool m_bStatsReceived = false;
 static Sint64 m_AppID = 0;
 static Sint64 m_hHighscoreLeaderboard = 0;
 static Sint64 m_hQpHighscoreLeaderboard = 0;
@@ -41,21 +40,6 @@ static Sint64 m_hMageHighscore = 0;
 static Sint64 m_hWeeklyHighscore = 0;
 
 static Timer *requestDataTimer = NULL;
-
-static bool
-steam_request_stats(void)
-{
-	if (m_Initiated)
-		return c_SteamUserStats_RequestCurrentStats();
-	return false;
-}
-
-static void
-stats_received(void)
-{
-	debug("Steam stats received");
-	m_bStatsReceived = true;
-}
 
 static void
 stats_stored(void)
@@ -98,7 +82,7 @@ steam_init()
 	m_Initiated = m_AppID != 0;
 	lb_weekly = time_get_weekly_lb_name();
 	if (m_Initiated)
-		c_SteamAPI_SetCallbacks(stats_received, stats_stored, leaderboard_received);
+		c_SteamAPI_SetCallbacks(stats_stored, leaderboard_received);
 	requestDataTimer = _timer_create();
 }
 
@@ -117,9 +101,7 @@ request_data_queue_run(void)
 		timer_start(requestDataTimer);
 
 	if (timer_get_ticks(requestDataTimer) > 1000) {
-		if (!m_bStatsReceived)
-			steam_request_stats();
-		else if (!m_hHighscoreLeaderboard)
+		if (!m_hHighscoreLeaderboard)
 			c_SteamUserStats_FindLeaderboard(LB_HIGHSCORE);
 		else if (!m_hQpHighscoreLeaderboard)
 			c_SteamUserStats_FindLeaderboard(LB_QUICKPLAY_HIGHSCORE);


### PR DESCRIPTION
This call should no longer be required. The stats will be loaded by
steam before game launch. This patch is stil untested.
