### PR TITLE
Update cmake req version and version handling

### DIFF
--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -73,6 +73,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: recursive
+        fetch-depth: 0
 
     - name: ccache
       uses: hendrikmuhs/ccache-action@v1.2
@@ -98,7 +99,9 @@ jobs:
           pkg-config \
           libopusfile-dev \
           libxmp-dev \
-          fluidsynth
+          fluidsynth \
+          libcmocka-dev \
+          cppcheck
 
     - name: Set up Macos dependencies
       if: ${{ runner.os == 'macOS' }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,14 +1,10 @@
-cmake_minimum_required (VERSION 3.6.0)
+cmake_minimum_required (VERSION 3.26)
 
 SET(CMAKE_COLOR_MAKEFILE ON)
 
 project(breakhack C)
 
 set(breakhack_GAME_TITLE "BreakHack")
-set(breakhack_MAJOR_VERSION 4)
-set(breakhack_MINOR_VERSION 0)
-set(breakhack_PATCH_VERSION 3)
-set(breakhack_RELEASE_TYPE "")
 
 # Checksums
 set(breakhack_STEAMAPI_DLL_CHECKSUM 0x1a4691a)
@@ -17,6 +13,13 @@ set(breakhack_STEAMAPI_SO_CHECKSUM 0x1a11b6d)
 include(build_deps/cmake/FindCCache.cmake)
 include(build_deps/cmake/FindCMocka.cmake)
 include(build_deps/cmake/Findcppcheck.cmake)
+include(build_deps/cmake/git_version.cmake)
+
+get_version_from_git()
+set(breakhack_MAJOR_VERSION ${PROJECT_VERSION_MAJOR})
+set(breakhack_MINOR_VERSION ${PROJECT_VERSION_MINOR})
+set(breakhack_PATCH_VERSION ${PROJECT_VERSION_PATCH})
+set(breakhack_RELEASE_TYPE "")
 
 configure_file(
 	"${PROJECT_SOURCE_DIR}/src/config.h.in"

--- a/build_deps/cmake/git_version.cmake
+++ b/build_deps/cmake/git_version.cmake
@@ -1,0 +1,47 @@
+function(get_version_from_git)
+    find_package(Git QUIET)
+    if(NOT Git_FOUND)
+        message(WARNING "Git not found")
+        return()
+    endif()
+
+    execute_process(
+        COMMAND ${GIT_EXECUTABLE} describe --tags --always
+        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+        OUTPUT_VARIABLE GIT_TAG
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+        RESULT_VARIABLE GIT_RESULT
+    )
+
+    if(NOT GIT_RESULT EQUAL 0)
+        message(WARNING "Failed to get git tag")
+        return()
+    endif()
+
+    execute_process(
+        COMMAND ${GIT_EXECUTABLE} rev-parse --short=7 HEAD
+        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+        OUTPUT_VARIABLE GIT_COMMIT_SHORT_HASH
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+
+    string(REGEX REPLACE "^v" "" CLEAN_TAG "${GIT_TAG}")
+    if(CLEAN_TAG MATCHES "^([0-9]+)\\.([0-9]+)\\.([0-9]+)(-.*)?$")
+
+        set(PROJECT_VERSION_MAJOR ${CMAKE_MATCH_1})
+        set(PROJECT_VERSION_MAJOR ${CMAKE_MATCH_1} PARENT_SCOPE)
+        set(PROJECT_VERSION_MINOR ${CMAKE_MATCH_2})
+        set(PROJECT_VERSION_MINOR ${CMAKE_MATCH_2} PARENT_SCOPE)
+        set(PROJECT_VERSION_PATCH ${CMAKE_MATCH_3})
+        set(PROJECT_VERSION_PATCH ${CMAKE_MATCH_3} PARENT_SCOPE)
+
+        set(FULL_VERSION "${CMAKE_MATCH_1}.${CMAKE_MATCH_2}.${CMAKE_MATCH_3}+${GIT_COMMIT_SHORT_HASH}")
+        set(FULL_VERSION "${CMAKE_MATCH_1}.${CMAKE_MATCH_2}.${CMAKE_MATCH_3}+${GIT_COMMIT_SHORT_HASH}" PARENT_SCOPE)
+        set(PROJECT_VERSION "${CMAKE_MATCH_1}.${CMAKE_MATCH_2}.${CMAKE_MATCH_3}")
+        set(PROJECT_VERSION "${CMAKE_MATCH_1}.${CMAKE_MATCH_2}.${CMAKE_MATCH_3}" PARENT_SCOPE)
+
+		message(STATUS "Found version: ${PROJECT_VERSION}, full: ${FULL_VERSION}")
+    else()
+        message(WARNING "Tag '${CLEAN_TAG}' does not match semver format")
+    endif()
+endfunction()

--- a/lib/bh_random/CMakeLists.txt
+++ b/lib/bh_random/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.6)
+cmake_minimum_required(VERSION 3.26)
 project(bh_random CXX)
 
 add_definitions(-std=c++11)

--- a/lib/checksum/CMakeLists.txt
+++ b/lib/checksum/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.6)
+cmake_minimum_required(VERSION 3.26)
 project(checksum C)
 
 if (NOT CMAKE_BUILD_TYPE)

--- a/lib/lua-5.3.5/CMakeLists.txt
+++ b/lib/lua-5.3.5/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.6)
+cmake_minimum_required (VERSION 3.26)
 
 SET(CMAKE_COLOR_MAKEFILE ON)
 

--- a/lib/physfs-3.0/CMakeLists.txt
+++ b/lib/physfs-3.0/CMakeLists.txt
@@ -9,7 +9,7 @@
 #  compile, using preprocessor checks for platform-specific bits instead of
 #  testing in here.
 
-cmake_minimum_required(VERSION 3.6)
+cmake_minimum_required(VERSION 3.26)
 
 project(PhysicsFS)
 set(PHYSFS_VERSION 3.0.1)

--- a/lib/steamworks_c_wrapper/CMakeLists.txt
+++ b/lib/steamworks_c_wrapper/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.6)
+cmake_minimum_required(VERSION 3.26)
 project(steamworks_c_wrapper CXX)
 
 if (NOT CMAKE_BUILD_TYPE)

--- a/scripts/build_steam_release.sh
+++ b/scripts/build_steam_release.sh
@@ -84,7 +84,7 @@ cat << EOT >> $STEAM_BUILD_DIR/app_build.vdf
 	"AppID" "931040" // your AppID
 	"Desc" "Vagrant provider:Docker, Ubuntu 24.04" // internal description for this build
 	"verbose" "0" // spew more build details in console
-	"preview" "1" // make this a preview build only, nothing is uploaded
+	"preview" "0" // make this a preview build only, nothing is uploaded
 
 	"ContentRoot" "content\" // root content folder, relative to location of this file
 	"BuildOutput" "output\" // build output folder for build logs and build cache files


### PR DESCRIPTION
The version is now calculated from the current git tag. Matching the
pattern vX.Y.Z. The latest patch in the branch will be used in the
build.
